### PR TITLE
Bare bone views for threads / messages

### DIFF
--- a/observant-otters/forumthing/forum/templates/forum/home.html
+++ b/observant-otters/forumthing/forum/templates/forum/home.html
@@ -5,6 +5,8 @@
     <title>does this like actually do stuff</title> <!-- so this is the title it shows on the tab apparently ~kevin -->
 </head>
 <body>
-no u
+Show-all-threads page
+<br><br>
+<a href="/forum/threads/1">Thread #1</a>
 </body>
 </html>

--- a/observant-otters/forumthing/forum/templates/forum/thread.html
+++ b/observant-otters/forumthing/forum/templates/forum/thread.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Only one group, up to homomorphism</title> <!-- so this is the title it shows on the tab apparently ~kevin -->
+</head>
+<body>
+Single-thread page
+   thread_id: {{ id }}
+   thread_page: {{ page }}
+</body>
+</html>

--- a/observant-otters/forumthing/forum/templates/forum/thread.html
+++ b/observant-otters/forumthing/forum/templates/forum/thread.html
@@ -6,7 +6,15 @@
 </head>
 <body>
 Single-thread page
-   thread_id: {{ id }}
-   thread_page: {{ page }}
+    <blockquote>
+        thread_id: {{ id }}
+        <br>
+        thread_page: {{ page }}
+    </blockquote>
+<a href="/forum/threads/{{ id }}?p={{ next_page }}">Next Page</a>
+<br>
+<a href="/forum/threads/{{ next_id }}?p={{ page }}">Next Thread</a>
+<br>
+<a href="/">Home</a>
 </body>
 </html>

--- a/observant-otters/forumthing/forum/urls.py
+++ b/observant-otters/forumthing/forum/urls.py
@@ -12,9 +12,9 @@ urlpatterns = [
         views.threads,
         name="threads-all"
     ),
-    re_path(
-        r"^forum/threads/(?P<id>\d+)/$",
-        views.threads,
-        name="threads-single"
-    )
+    path(
+      'forum/threads/<int:id>',
+      views.threads,
+      name='threads-single'
+    ),
 ]

--- a/observant-otters/forumthing/forum/urls.py
+++ b/observant-otters/forumthing/forum/urls.py
@@ -1,6 +1,20 @@
-from django.urls import path
+from django.urls import path, re_path
 from . import views
 
 urlpatterns = [
-    path('', views.home, name='forum-homepage'),
+    path(
+        "",
+        views.home,
+        name="forum-homepage"
+    ),
+    path(
+        'forum/threads',
+        views.threads,
+        name="threads-all"
+    ),
+    re_path(
+        r"^forum/threads/(?P<id>\d+)/$",
+        views.threads,
+        name="threads-single"
+    )
 ]

--- a/observant-otters/forumthing/forum/views.py
+++ b/observant-otters/forumthing/forum/views.py
@@ -1,4 +1,34 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 
 def home(request):
-    return render(request, 'forum/home.html', {})
+    return redirect("threads-all")
+
+def threads(request, id=None):
+    if request.method == "GET":
+        if id is None:
+            return render(request, 'forum/home.html', {})
+        else:
+            p= request.GET.get("p", default=1)
+            data= {
+                "id": id,
+                "page": p,
+
+                # @TODO: Remove debug values
+                "next_page": int(p)+1,
+                "next_id": int(id)+1
+            }
+            return render(request, 'forum/thread.html', data)
+
+    elif request.method == "POST":
+        if id is None:
+            pass # @TODO: Handle new thread creation
+        else:
+            pass # @TODO: Handle new thread reply creation
+
+    elif request.method == "DELETE":
+        assert id is not None, "Thread deletion without id"
+        # @TODO: Handle thread deletion
+
+    elif request.method == "PATCH":
+        assert id is not None, "Thread edit without id"
+        # @TODO: Handle thread deletion

--- a/observant-otters/forumthing/forum/views.py
+++ b/observant-otters/forumthing/forum/views.py
@@ -1,15 +1,17 @@
 from django.shortcuts import render, redirect
 
+
 def home(request):
     return redirect("threads-all")
+
 
 def threads(request, id=None):
     if request.method == "GET":
         if id is None:
             return render(request, 'forum/home.html', {})
         else:
-            p= request.GET.get("p", default=1)
-            data= {
+            p = request.GET.get("p", default=1)
+            data = {
                 "id": id,
                 "page": p,
 
@@ -21,9 +23,9 @@ def threads(request, id=None):
 
     elif request.method == "POST":
         if id is None:
-            pass # @TODO: Handle new thread creation
+            pass  # @TODO: Handle new thread creation
         else:
-            pass # @TODO: Handle new thread reply creation
+            pass  # @TODO: Handle new thread reply creation
 
     elif request.method == "DELETE":
         assert id is not None, "Thread deletion without id"
@@ -31,4 +33,4 @@ def threads(request, id=None):
 
     elif request.method == "PATCH":
         assert id is not None, "Thread edit without id"
-        # @TODO: Handle thread deletion
+        # @TODO: Handle thread edit

--- a/observant-otters/forumthing/user/urls.py
+++ b/observant-otters/forumthing/user/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, re_path
+from . import views
+
+urlpatterns = [
+	re_path(
+        r"^forum/messages/(?P<id>\d+)/$",
+        views.message,
+        name="message-action"
+    )
+]

--- a/observant-otters/forumthing/user/urls.py
+++ b/observant-otters/forumthing/user/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, re_path
 from . import views
 
 urlpatterns = [
-	re_path(
+    re_path(
         r"^forum/messages/(?P<id>\d+)/$",
         views.message,
         name="message-action"

--- a/observant-otters/forumthing/user/views.py
+++ b/observant-otters/forumthing/user/views.py
@@ -1,8 +1,9 @@
 from django.shortcuts import render
 
+
 def message(request, id):
     if request.method == "DELETE":
-        pass # @TODO: Handle message deletion
+        pass  # @TODO: Handle message deletion
 
     elif request.method == "PATCH":
-        pass # @TODO: Handle message edit
+        pass  # @TODO: Handle message edit

--- a/observant-otters/forumthing/user/views.py
+++ b/observant-otters/forumthing/user/views.py
@@ -1,3 +1,8 @@
 from django.shortcuts import render
 
-# Create your views here.
+def message(request, id):
+    if request.method == "DELETE":
+        pass # @TODO: Handle message deletion
+
+    elif request.method == "PATCH":
+        pass # @TODO: Handle message edit


### PR DESCRIPTION
Added views to handle each path below. The GETs still return an almost-empty template. Code for the other HTTP methods are just a placeholder if-block.

- `GET /` -- Redirect to /forum/threads
    - Done
- `GET /forum/threads` -- Returns a list of threads
- `GET /forum/threads/:id?p=:page` -- Get specific thread {id} and X messages 
    - Added thread template.

- `POST /forum/threads/:id` -- Post new message to thread
- `POST /forum/threads` -- Create new thread
- `DELETE /forum/threads/:id` -- Delete thread (only for author of thread)
- `PATCH /forum/threads/:id` -- Edit thread (only for author of thread)
- `DELETE /forum/messages/:id` -- Delete message
- `PATCH /forum/messages/:id` -- Edit message
